### PR TITLE
Synchronous start

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -71,7 +71,7 @@ function findProcessWithIndex( index, callback ) {
 function startForeverWithIndex( index ) {
   log( 'Attempting to start ' + index + ' as daemon.');
 
-  done = this.async;
+  done = this.async();
   findProcessWithIndex( index, function(process) {
     // if found, be on our way without failing.
     if( typeof process !== 'undefined' ) {


### PR DESCRIPTION
Hi!,

I've noticed that start has a typo. in consequence it was synchronous (which is obviously wrong).

Cheers
