### PR TITLE
fixes processes not starting when logDir set

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -171,9 +171,11 @@ module.exports = function(grunt) {
           operation = target;
 
       commandName = this.options().command;
-      logDir  = this.options().logDir && path.join(process.cwd(), this.options().logDir) || logDir;
-      logFile = this.options().logFile && path.join(logDir, this.options().logFile) || logFile;
-      errFile = this.options().errFile && path.join(logDir, this.options().errFile) || errFile;
+      if (this.options().logDir) {
+        logDir  = path.join(process.cwd(), this.options().logDir) || logDir;
+        logFile = path.join(logDir, this.options().logFile || 'out.log');
+        errFile = path.join(logDir, this.options().errFile || 'err.log');
+      }
 
       try {
         if(commandMap.hasOwnProperty(operation)) {


### PR DESCRIPTION
Fixes issue #9. Previously the conditions used to set logFile and errFile depended on them being set, so omitting them from your grunfile config caused them to default to the forever directory. This will set them if logDir is set in the config.
