### PR TITLE
add 'killSignal' option for forever

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -3,6 +3,7 @@ var forever     = require('forever'),
     logDir      = path.join(process.cwd(), '/forever'),
     logFile     = path.join(logDir, '/out.log'),
     errFile     = path.join(logDir, '/err.log'),
+    killSignal  = 'SIGKILL'
     commandName = 'node',
     commandMap  = {
       start:      startForeverWithIndex,

--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -90,7 +90,8 @@ function startForeverWithIndex( index ) {
         outFile: logFile,
         command: commandName,
         append: true,
-        max: 3
+        max: 3,
+        killSignal: killSignal
       });
       log( 'Logs can be found at ' + logDir + '.' );
       done();
@@ -174,6 +175,7 @@ module.exports = function(grunt) {
       logDir  = this.options().logDir && path.join(process.cwd(), this.options().logDir) || logDir;
       logFile = this.options().logFile && path.join(logDir, this.options().logFile) || logFile;
       errFile = this.options().errFile && path.join(logDir, this.options().errFile) || errFile;
+      killSignal = this.options().killSignal || 'SIGKILL'
 
       try {
         if(commandMap.hasOwnProperty(operation)) {


### PR DESCRIPTION
I added the option to specify the killSignal that forever uses to kill scripts.  My projects need to catch the terminate signal and do cleanup, which forever's default SIGKILL prevents.  Now you can specify SIGTERM instead.