### PR TITLE
Fixed forever:server:restart task.

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -142,10 +142,7 @@ function restartOnProcess( index ) {
   findProcessWithIndex( index, function(process) {
     if(typeof process !== 'undefined') {
       log(forever.format(true,[process]));
-
-      forever.stop(index).on('stop', function(){
-          startRequest();
-      })
+      forever.restart(index, false);
 
     }
     else {


### PR DESCRIPTION
forever:server:restart should behave like the cli

``` bash
$ forever restart foo.js
```

This patch does exactly that with the difference that disables output formatting.  I am not sure if done() needs to be invoked or not, but it seems to make no difference as far as I have observed.

Please accept, grunt-forever is broken without it.
