### PR TITLE
Make sure the done() callback is invoked when processing server:restart.

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -147,8 +147,8 @@ function restartOnProcess( index ) {
     else {
       log(index + ' not found in list of processes in forever. Starting new instance...');
       startRequest();
-      done();
     }
+    done();
   });
 }
 


### PR DESCRIPTION
Turns out that the done() callback is essential or restart hangs.
