### PR TITLE
Added an option to pass the operation for the forever grunt task

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask( 'forever', 'Starts node app as a daemon.', function(target) {
 
       var index = this.options().index || 'index.js',
-          operation = target || 'start';
+          operation = target || this.options().operation || 'start';
 
       commandName = this.options().command;
       if (this.options().logDir) {


### PR DESCRIPTION
using the operation of start, stop, or restart. It would be ideal to be able to run individual operations based and environment and specific need.
