### PR TITLE
added 'operation' config paramter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ File stderr is logged into, defaults to 'err.log'.
 
 File stdout is logged into, defaults to 'out.log'.
 
+##### operation ```string```
+
+Allows assigning a task to a certain operation (start/ stop/ restart).
+If a named argument is provided, it will overwrite the operation variable
+
 ### Config Example
 ```javascript
 forever: {
@@ -90,6 +95,14 @@ forever: {
       logDir: 'logs'
     }
   }
+  
+  restartServer1: {
+      options: {
+        operation: "restart",
+        index: 'index.js',
+        logDir: 'logs'
+      }
+    }
 }
 ```
 
@@ -105,3 +118,12 @@ grunt forever:server2:stop
 ```bash
 grunt forever:server1:restart
 ```
+
+```bash
+grunt forever:restartServer1
+```
+
+```bash
+grunt forever:restartServer1:stop
+```
+will stop server1

--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -6,9 +6,9 @@ var forever     = require('forever'),
     logFile     = path.join(logDir, '/log.log'),
     commandName = 'node',
     commandMap  = {
-      start:      startForeverWithIndex,
-      stop:       stopOnProcess,
-      restart:    restartOnProcess
+        start:      startForeverWithIndex,
+        stop:       stopOnProcess,
+        restart:    restartOnProcess
     },
     done, gruntRef;
 
@@ -17,21 +17,21 @@ var forever     = require('forever'),
  * @param  {String} message Message to print with log formatting.
  */
 function log( message ) {
-  gruntRef.log.writeln( message );
+    gruntRef.log.writeln( message );
 }
 /**
  * Logs message to console using warn() from grunt.
  * @param  {String} message Message to print with warn formatting.
  */
 function warn( message ) {
-  gruntRef.warn( message );
+    gruntRef.warn( message );
 }
 /**
  * Logs message to console using log.error() and raises error from grunt.
  * @param  {String} message Message to print in error formatting.
  */
 function error( message ) {
-  gruntRef.log.error( message ).error();
+    gruntRef.log.error( message ).error();
 }
 /**
  * Pretty prints supplied object in JSON notation using grunt logging.
@@ -39,7 +39,7 @@ function error( message ) {
  * @param  {Object} object Generic Object to be JSON-ified.
  */
 function prettyPrint( id, object ) {
-  log(id + ' : ' + JSON.stringify(object, null, 2));
+    log(id + ' : ' + JSON.stringify(object, null, 2));
 }
 /**
  * Locates running process previously started by forever based on index file, and notifies callback. Will notify of undefined if not found, other wise the unformatted process object.
@@ -47,111 +47,111 @@ function prettyPrint( id, object ) {
  * @param  {Function} callback Delegate method to invoke with either the found process object or undefined if not found.
  */
 function findProcessWithIndex( index, callback ) {
-  var i, process;
-  try {
-    forever.list(false, function(context, list) {
-      i = list ? list.length : 0;
-      while( --i > -1 ) {
-        process = list[i];
-        if( process.hasOwnProperty('file') &&
-          process.file === index ) {
-          break;
-        }
-        process = undefined;
-      }
+    var i, process;
+    try {
+        forever.list(false, function(context, list) {
+            i = list ? list.length : 0;
+            while( --i > -1 ) {
+                process = list[i];
+                if( process.hasOwnProperty('file') &&
+                    process.file === index ) {
+                    break;
+                }
+                process = undefined;
+            }
 
-      callback.call(null, process);
-    });
-  }
-  catch( e ) {
-    error( 'Error in trying to find process ' + index + ' in forever. [REASON] :: ' + e.message );
-    callback.call(null, undefined);
-  }
+            callback.call(null, process);
+        });
+    }
+    catch( e ) {
+        error( 'Error in trying to find process ' + index + ' in forever. [REASON] :: ' + e.message );
+        callback.call(null, undefined);
+    }
 }
 /**
  * Attempts to start process using the index file.
  * @param  {String} index Filename.
  */
 function startForeverWithIndex( index ) {
-  log( 'Attempting to start ' + index + ' as daemon.');
+    log( 'Attempting to start ' + index + ' as daemon.');
 
-  done = this.async();
-  findProcessWithIndex( index, function(process) {
-    // if found, be on our way without failing.
-    if( typeof process !== 'undefined' ) {
-      warn( index + ' is already running.');
-      log( forever.format(true, [process]) );
-      done();
-    }
-    else {
-      gruntRef.file.mkdir(logDir);
-      // 'forever start -o out.log -e err.log -c node -a -m 3 index.js';
-      forever.startDaemon( index, {
-        errFile: errFile,
-        outFile: outFile,
-        logFile: logFile,
-        command: commandName,
-        append: true,
-        max: 3
-      });
-      log( 'Logs can be found at ' + logDir + '.' );
-      done();
-    }
-  });
+    done = this.async();
+    findProcessWithIndex( index, function(process) {
+        // if found, be on our way without failing.
+        if( typeof process !== 'undefined' ) {
+            warn( index + ' is already running.');
+            log( forever.format(true, [process]) );
+            done();
+        }
+        else {
+            gruntRef.file.mkdir(logDir);
+            // 'forever start -o out.log -e err.log -c node -a -m 3 index.js';
+            forever.startDaemon( index, {
+                errFile: errFile,
+                outFile: outFile,
+                logFile: logFile,
+                command: commandName,
+                append: true,
+                max: 3
+            });
+            log( 'Logs can be found at ' + logDir + '.' );
+            done();
+        }
+    });
 }
 /**
  * Attempts to stop a process previously started associated with index.
  * @param  {String} index Filename associated with previously started process.
  */
 function stopOnProcess(index) {
-  log( 'Attempting to stop ' + index + '...' );
+    log( 'Attempting to stop ' + index + '...' );
 
-  done = this.async();
-  findProcessWithIndex( index, function(process) {
-    if( typeof process !== 'undefined' ) {
-      log( forever.format(true,[process]) );
+    done = this.async();
+    findProcessWithIndex( index, function(process) {
+        if( typeof process !== 'undefined' ) {
+            log( forever.format(true,[process]) );
 
-      forever.stop( index )
-        .on('stop', function() {
-          done();
-        })
-        .on('error', function(message) {
-          error( 'Error stopping ' + index + '. [REASON] :: ' + message );
-          done(false);
-        });
-    }
-    else {
-      gruntRef.warn( index + ' not found in list of processes in forever.' );
-      done();
-    }
-  });
+            forever.stop( index )
+                .on('stop', function() {
+                    done();
+                })
+                .on('error', function(message) {
+                    error( 'Error stopping ' + index + '. [REASON] :: ' + message );
+                    done(false);
+                });
+        }
+        else {
+            gruntRef.warn( index + ' not found in list of processes in forever.' );
+            done();
+        }
+    });
 }
 /**
  * Attempts to stop and restart a process previously started associated with index. If no process found as previously started, just starts a new one.
  * @param  {String} index Filename associated with previously started process.
  */
 function restartOnProcess( index ) {
-  log( 'Attempting to restart ' + index + '...' );
+    log( 'Attempting to restart ' + index + '...' );
 
-  // generate delegate function to pass with proper contexts.
-  var startRequest = (function(context, index) {
-    return function() {
-        startForeverWithIndex.call(context, index);
-    };
-  }(this, index));
+    // generate delegate function to pass with proper contexts.
+    var startRequest = (function(context, index) {
+        return function() {
+            startForeverWithIndex.call(context, index);
+        };
+    }(this, index));
 
-  done = this.async();
-  findProcessWithIndex( index, function(process) {
-    if(typeof process !== 'undefined') {
-      log(forever.format(true,[process]));
-      forever.restart(index, false);
-    }
-    else {
-      log(index + ' not found in list of processes in forever. Starting new instance...');
-      startRequest();
-    }
-    done();
-  });
+    done = this.async();
+    findProcessWithIndex( index, function(process) {
+        if(typeof process !== 'undefined') {
+            log(forever.format(true,[process]));
+            forever.restart(index, false);
+        }
+        else {
+            log(index + ' not found in list of processes in forever. Starting new instance...');
+            startRequest();
+        }
+        done();
+    });
 }
 
 /**
@@ -160,30 +160,30 @@ function restartOnProcess( index ) {
  */
 module.exports = function(grunt) {
 
-  gruntRef = grunt;
-  grunt.registerMultiTask( 'forever', 'Starts node app as a daemon.', function(target) {
+    gruntRef = grunt;
+    grunt.registerMultiTask( 'forever', 'Starts node app as a daemon.', function(target) {
 
-      var index = this.options().index || 'index.js',
-          operation = target || 'start';
+        var index = this.options().index || 'index.js',
+            operation = target || this.options().operation || 'start';
 
-      commandName = this.options().command;
-      if (this.options().logDir) {
-        logDir  = path.join(process.cwd(), this.options().logDir) || logDir;
-        outFile = path.join(logDir, this.options().outFile || 'out.log');
-        errFile = path.join(logDir, this.options().errFile || 'err.log');
-        logFile = path.join(logDir, this.options().logFile || 'log.log');
-      }
-
-      try {
-        if(commandMap.hasOwnProperty(operation)) {
-          commandMap[operation].call(this, index);
+        commandName = this.options().command;
+        if (this.options().logDir) {
+            logDir  = path.join(process.cwd(), this.options().logDir) || logDir;
+            outFile = path.join(logDir, this.options().outFile || 'out.log');
+            errFile = path.join(logDir, this.options().errFile || 'err.log');
+            logFile = path.join(logDir, this.options().logFile || 'log.log');
         }
-        else {
-          warn('Operation ' + operation + ' is not supported currently. Only forever:start, forever:stop or forever:restart.');
+
+        try {
+            if(commandMap.hasOwnProperty(operation)) {
+                commandMap[operation].call(this, index);
+            }
+            else {
+                warn('Operation ' + operation + ' is not supported currently. Only forever:start, forever:stop or forever:restart.');
+            }
         }
-      }
-      catch(e) {
-          error('Exception thrown in attempt to ' + operation + ' on ' + index + ': ' + e);
-      }
-  });
+        catch(e) {
+            error('Exception thrown in attempt to ' + operation + ' on ' + index + ': ' + e);
+        }
+    });
 };


### PR DESCRIPTION
by merely update the line "operation = target || this.options().operation || 'start';"
I've allowed passing the operation value as part of the options.
This was important for me because I run the task as a series of tasks (test,compile,build,copy and eventually restarting the server - as opposed to merely 'starting' the server).

(sadly, my editor also re-formatted so it looks like there're more changes than this)
