### PR TITLE
Remove limit of maximum restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,16 @@
 {
-  "name": "grunt-forever",
-  "description": "Grunt task for starting and stopping an application as a daemon using forever",
-  "version": "0.4.5",
-  "homepage": "https://github.com/bustardcelly/grunt-forever",
+  "name": "mhe-grunt-forever",
+  "description": "Grunt task for starting and stopping an application as a daemon using forever with unlimited retires, forked from the node module grunt-forever",
+  "version": "0.1.0",
+  "homepage": "https://github.com/MHE-Analytics/grunt-forever",
   "author": {
     "name": "Todd Anderson",
     "url": "http://custardbelly.com/blog"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/bustardcelly/grunt-forever.git"
+    "url": "https://github.com/MHE-Analytics/grunt-forever.git"
   },
-  "bugs": {
-    "url": "git://github.com/bustardcelly/grunt-forever/issues"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/bustardcelly/grunt-forever/blob/master/LICENSE-MIT"
-    }
-  ],
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.10.0"
@@ -44,6 +35,7 @@
     "grunt",
     "gruntplugin",
     "plugins",
-    "daemon"
+    "daemon",
+    "mhe"
   ]
 }

--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -91,8 +91,7 @@ function startForeverWithIndex( index ) {
         outFile: outFile,
         logFile: logFile,
         command: commandName,
-        append: true,
-        max: 3
+        append: true
       });
       log( 'Logs can be found at ' + logDir + '.' );
       done();


### PR DESCRIPTION
Remove maximum restart limit. Renamed to create a new npm module.
The functionality is tested locally by using a soft link from the npm_module/grunt-forever to this repo.