### PR TITLE
Allow keeping logs outside of the process cwd

### DIFF
--- a/tasks/forever-task.js
+++ b/tasks/forever-task.js
@@ -176,7 +176,11 @@ module.exports = function(grunt) {
           operation = target || 'start';
 
       commandName = this.options().command;
-      logDir = undefined !== this.options().logDir ? path.join(process.cwd(), this.options().logDir) : logDir;
+
+      if (this.options().logDir) {
+        logDir = this.options().logDir.indexOf('/') === 0 ? this.options().logDir : path.join(process.cwd(), this.options().logDir);
+      }
+
       outFile = undefined !== this.options().outFile ? path.join(logDir, this.options().outFile) : outFile;
       errFile = undefined !== this.options().errFile ? path.join(logDir, this.options().errFile) : errFile;
       logFile = undefined !== this.options().logFile ? path.join(logDir, this.options().logFile) : logFile;


### PR DESCRIPTION
Fixes #21 

There are now 3 different ways of settings the logDir for logs

1) LogDir is set to `/<dir>/`

> The logs will be stored in `/<dir>/.`

2) LogDir is set to `<dir>`

> The logs will be stored in `./<dir>/.`

3) LogDir is not set

> The logs will be stored in `./forever/.`
